### PR TITLE
Reintain information about placed paranthese

### DIFF
--- a/lib/lucene-query.grammar
+++ b/lib/lucene-query.grammar
@@ -149,6 +149,7 @@ group_exp
 paren_exp
   = "(" node:node+ ")" _*
     {
+        node[0]['parenthesized'] = true;
         return node[0];
     }
 
@@ -328,5 +329,3 @@ _ "whitespace"
 
 EOF
   = !.
-
-

--- a/lib/lucene-queryparser.js
+++ b/lib/lucene-queryparser.js
@@ -471,6 +471,7 @@ module.exports = (function(){
         }
         if (result0 !== null) {
           result0 = (function(offset, node) {
+                node[0]['parenthesized'] = true;
                 return node[0];
             })(pos0, result0[1]);
         }

--- a/spec/lucene-queryparser.spec.js
+++ b/spec/lucene-queryparser.spec.js
@@ -225,11 +225,13 @@ describe("lucenequeryparser: parentheses groups", function() {
 
         expect(results['left']['term']).toBe('fizz');
         expect(results['operator']).toBe('<implicit>');
+        expect(results['parenthesized']).toBe(undefined);
 
         var rightNode = results['right'];
 
         expect(rightNode['left']['term']).toBe('buzz');
         expect(rightNode['operator']).toBe('<implicit>');
+        expect(rightNode['parenthesized']).toBe(true);
         expect(rightNode['right']['term']).toBe('baz');
     });
 


### PR DESCRIPTION
This is interesting in order to gain the ability to reconstruct user
queries from a parsed query.

Use case is to parse a query, manipulate the result and turn it back
into a query.